### PR TITLE
Replace flake8 with ruff and remove stale Bandit nosec marker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install \
-            flake8 \
+            ruff \
             bandit \
             pytest \
             pandas \
@@ -35,8 +35,8 @@ jobs:
             joblib
 
       # ── Lint ──────────────────────────────────────────────────────────────
-      - name: flake8
-        run: flake8 outlook_triage.py train_model.py --max-line-length=120
+      - name: ruff
+        run: ruff check outlook_triage.py train_model.py --line-length=120
 
       # ── Security scan ─────────────────────────────────────────────────────
       - name: bandit (medium + high severity only)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Local-only Windows email triage automation for Microsoft Outlook (Classic/COM). 
 
 ```bash
 # Lint (max line length 120)
-flake8 outlook_triage.py train_model.py --max-line-length=120
+ruff check outlook_triage.py train_model.py --line-length=120
 
 # Security scan (medium+ severity)
 bandit outlook_triage.py train_model.py -ll
@@ -62,4 +62,4 @@ Tests run cross-platform (Linux/CI). `tests/conftest.py` mocks `win32com`/`pytho
 
 ## CI
 
-`.github/workflows/ci.yml` runs on Ubuntu (Python 3.12): flake8 → bandit → pytest.
+`.github/workflows/ci.yml` runs on Ubuntu (Python 3.12): ruff → bandit → pytest.

--- a/train_model.py
+++ b/train_model.py
@@ -144,7 +144,7 @@ def build_pipeline() -> Pipeline:
             (
                 "sender_tfidf",
                 TfidfVectorizer(
-                    token_pattern=r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+",  # nosec B106
+                    token_pattern=r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+",
                     min_df=1,
                 ),
                 "sender_email",


### PR DESCRIPTION
### Motivation
- Remove an unnecessary `# nosec B106` suppression that triggered a Bandit warning and standardize linting tooling in CI to `ruff`.

### Description
- Updated `.github/workflows/ci.yml` to install `ruff` and run `ruff check` in place of `flake8`.
- Updated `CLAUDE.md` to reference the new `ruff` lint command and CI ordering.
- Removed the `# nosec B106` comment from the email regex in `train_model.py` to avoid a misleading Bandit nosec warning.

### Testing
- Ran `ruff check outlook_triage.py train_model.py --line-length=120` with no failures.
- Ran `bandit outlook_triage.py train_model.py -ll` and confirmed the previous `nosec encountered (B106)` warning is no longer emitted.
- Ran `python -m pytest tests/ -v --tb=short` and all tests passed (`137 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b6a4e02454832eac15de1457bebc00)