### PR TITLE
Address low-severity Bandit findings without behavior changes

### DIFF
--- a/outlook_triage.py
+++ b/outlook_triage.py
@@ -226,8 +226,8 @@ def get_sender_email(mail_item) -> str:
         addr = safe_str(mail_item.SenderEmailAddress)
         if addr and "@" in addr:
             return addr.lower()
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug(f"Unable to read SenderEmailAddress directly: {e}")
 
     try:
         sender = mail_item.Sender
@@ -237,8 +237,8 @@ def get_sender_email(mail_item) -> str:
                 smtp = safe_str(ex_user.PrimarySmtpAddress)
                 if smtp and "@" in smtp:
                     return smtp.lower()
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug(f"Unable to resolve Exchange sender SMTP address: {e}")
 
     return ""
 
@@ -264,8 +264,8 @@ def thread_depth(mail_item) -> int:
         idx = safe_str(getattr(mail_item, "ConversationIndex", ""))
         if len(idx) > 44:
             return (len(idx) - 44) // 10
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug(f"Unable to derive conversation thread depth: {e}")
     return 0
 
 
@@ -287,8 +287,8 @@ def already_triaged(mail_item) -> bool:
             for cat in cats.split(","):
                 if cat.strip() in TRIAGE_CATEGORIES:
                     return True
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug(f"Unable to inspect existing categories: {e}")
     return False
 
 
@@ -352,8 +352,8 @@ def rule_score_and_bucket(
         if attach_count > 0:
             score += 8
             reasons.append("has_attachment")
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug(f"Unable to inspect attachment count: {e}")
 
     age_hours = 0.0
     try:
@@ -361,8 +361,8 @@ def rule_score_and_bucket(
         if age_hours > 24:
             score -= int(min(25, age_hours // 24 * 5))
             reasons.append("age_penalty")
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug(f"Unable to compute age penalty: {e}")
 
     noise = is_noise(subject, sender_email, noise_pats)
     if noise:
@@ -512,8 +512,8 @@ def collect_items(inbox) -> list:
                 entry_id = safe_str(getattr(item, "EntryID", ""))
                 if entry_id:
                     result.append(entry_id)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Skipping item during inbox scan due to COM error: {e}")
         try:
             item = items.GetNext()
         except Exception:

--- a/train_model.py
+++ b/train_model.py
@@ -144,7 +144,7 @@ def build_pipeline() -> Pipeline:
             (
                 "sender_tfidf",
                 TfidfVectorizer(
-                    token_pattern=r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+",
+                    token_pattern=r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+",  # nosec B106 (email regex, not credential)
                     min_df=1,
                 ),
                 "sender_email",


### PR DESCRIPTION
### Motivation
- Reduce low-severity Bandit noise by avoiding silent `except Exception: pass` blocks while preserving existing fallback behavior in Outlook COM best-effort paths.
- Silence a Bandit false-positive for an email regex used as a `TfidfVectorizer` `token_pattern` so the model pipeline remains unchanged.

### Description
- Replace several `except Exception: pass` blocks in `outlook_triage.py` with `logger.debug(...)` messages in the sender resolution, conversation thread depth, category inspection, attachment counting, age penalty computation, and inbox scan loop so errors are logged at debug level but behavior falls back unchanged.
- Add an inline `# nosec B106` annotation to the `token_pattern` email regex in `train_model.py` to document and suppress the Bandit `hardcoded_password_funcarg` false positive.
- No logic or thresholds affecting triage scoring or model training were changed.

### Testing
- Ran `bandit outlook_triage.py train_model.py -l` after changes and it reported no issues.
- Ran the test suite with `python -m pytest tests/ -v --tb=short` and all tests passed (`137 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b6a7302308832e8671ab559dcb6ed9)